### PR TITLE
Add some missing copyright lines to some DSLogic-fw files.

### DIFF
--- a/DSLogic.c
+++ b/DSLogic.c
@@ -1,6 +1,8 @@
 /*
  * This file is part of the DSLogic-fw project.
  *
+ * Copyright (C) 2012 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2012 Joel Holdsworth <joel@airwebreathe.org.uk>
  * Copyright (C) 2014 DreamSourceLab <support@dreamsourcelab.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ##
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,7 +2,7 @@
 ##
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 ##
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/fx2lib/Makefile.am
+++ b/fx2lib/Makefile.am
@@ -1,7 +1,7 @@
 ##
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/fx2lib/include/Makefile.am
+++ b/fx2lib/include/Makefile.am
@@ -1,7 +1,7 @@
 ##
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/fx2lib/lib/Makefile.am
+++ b/fx2lib/lib/Makefile.am
@@ -1,7 +1,7 @@
 ###
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/fx2lib/lib/interrupts/Makefile.am
+++ b/fx2lib/lib/interrupts/Makefile.am
@@ -1,7 +1,7 @@
 ##
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/hw/Makefile.am
+++ b/hw/Makefile.am
@@ -1,7 +1,7 @@
 ##
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,7 +1,7 @@
 ##
 ## This file is part of the DSLogic-fw project.
 ##
-## Copyright (C) 2014 DreamSourceLab <dreamsourcelab@dreamsourcelab.com>
+## Copyright (C) 2013 Uwe Hermann <uwe@hermann-uwe.de>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/include/dscr.inc
+++ b/include/dscr.inc
@@ -1,6 +1,8 @@
 ;;
 ;; This file is part of the DSLogic-fw project.
 ;;
+;; Copyright (C) 2011-2012 Uwe Hermann <uwe@hermann-uwe.de>
+;; Copyright (C) 2012 Joel Holdsworth <joel@airwebreathe.org.uk>
 ;; Copyright (C) 2014 DreamSourceLab <support@dreamsourcelab.com>
 ;;
 ;; This program is free software; you can redistribute it and/or modify

--- a/interface.c
+++ b/interface.c
@@ -1,6 +1,8 @@
 /*
  * This file is part of the DSLogic-fw project.
  *
+ * Copyright (C) 2012 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2012 Joel Holdsworth <joel@airwebreathe.org.uk>
  * Copyright (C) 2014 DreamSourceLab <support@dreamsourcelab.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/usb.c
+++ b/usb.c
@@ -1,6 +1,8 @@
 /*
  * This file is part of the DSLogic-fw project.
  *
+ * Copyright (C) 2012 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2012 Joel Holdsworth <joel@airwebreathe.org.uk>
  * Copyright (C) 2014 DreamSourceLab <support@dreamsourcelab.com>
  *
  * This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
The code in DSLogic-fw is partly based on fx2lafw (as acknowledged in
the DSLogic-fw README file).

The following are (almost) identical files where only renaming happened
(fx2lafw -> DSLogic-fw, sigrok.org -> DreamSourceLab.com, simple file
renames, and so on). Keep the original fx2lafw copyright lines here, there
are no non-trivial changes by DreamSourceLab here to warrant copyright line
replacement, IMHO.
- Makefile.am
- autogen.sh
- configure.ac
- fx2lib/Makefile.am
- fx2lib/include/Makefile.am
- fx2lib/lib/Makefile.am
- fx2lib/lib/interrupts/Makefile.am
- hw/Makefile.am (corresponds to fx2lafw's hw/Makefile.inc)
- include/Makefile.am

The above is the autoconf/automake build system I wrote for fx2lafw in
2013, which nicely integrates the fx2lafw code, the sdcc toolchain and
(parts of) fx2lib in a portable manner (across distros, OSes, as well as
sdcc versions).

Yes, _some_ (but certainly not all) of the above files may be somewhat
trivial, but at the same time they do not contain any non-trivial
DreamSourceLab changes either, so the coypright lines may as well be left
unchanged (as the rest of the file contents).

The following files contain both code that originates from fx2lafw as
well as various non-trivial changes and/or additions from DreamSourceLab.
Thus, use both the original fx2lafw copyright lines as well as the
DreamSourceLab copyright line.
- DSLogic.c
- interface.c
- usb.c
- include/dscr.inc

There are a few other files which seem to be at least inspired by their
respective fx2lafw counterparts, but are too trivial or irrelevant to
worry about anyway, so omitting those.
